### PR TITLE
replacing plot3D for a class Plot3D

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ MANIFEST
 .settings/
 *.ipynb_checkpoints
 *egg-info
+__pycache__

--- a/examples/basic_course/02-Surfaces.ipynb
+++ b/examples/basic_course/02-Surfaces.ipynb
@@ -55,7 +55,7 @@
    ],
    "source": [
     "P1=Plane(shape=Circular(radius=(25)))\n",
-    "plot3D(P1,center=(0,0,0),size=(60,60),rot=[(0,0,0)],scale=6)"
+    "Plot3D(P1,center=(0,0,0),size=(60,60),rot=[(0,0,0)],scale=6)"
    ]
   },
   {
@@ -79,7 +79,7 @@
    ],
    "source": [
     "P2=Plane(shape=Rectangular(size=(50,50)))\n",
-    "plot3D(P2,center=(0,0,0),size=(60,60),rot=[(0,0,0)],scale=6)"
+    "Plot3D(P2,center=(0,0,0),size=(60,60),rot=[(0,0,0)],scale=6)"
    ]
   },
   {
@@ -103,7 +103,7 @@
    ],
    "source": [
     "P3=Plane(shape=Triangular(coord=((0,25),(25,-25),(-25,-25))))\n",
-    "plot3D(P3,center=(0,0,0),size=(60,60),scale=6) "
+    "Plot3D(P3,center=(0,0,0),size=(60,60),scale=6) "
    ]
   },
   {
@@ -134,7 +134,7 @@
    ],
    "source": [
     "S=Spherical(curvature=1/200., shape=Circular(radius=145.),reflectivity=0)\n",
-    "plot3D(S,center=(0,0,0),size=(400,400),scale=1)"
+    "Plot3D(S,center=(0,0,0),size=(400,400),scale=1)"
    ]
   },
   {
@@ -165,7 +165,7 @@
    ],
    "source": [
     "S3=Cylinder(radius=36,length=100,reflectivity=1)\n",
-    "plot3D(S3,center=(0,0,0),size=(100,100),rot=[(0,pi/32,0)],scale=4)"
+    "Plot3D(S3,center=(0,0,0),size=(100,100),rot=[(0,pi/32,0)],scale=4)"
    ]
   },
   {
@@ -197,7 +197,7 @@
    ],
    "source": [
     "S1=Cylindrical(shape=Rectangular(size=(50,100)),curvature=1/20.)\n",
-    "plot3D(S1,center=(0,0,0),size=(150,150),rot=[(pi/4,0,0)],scale=2)"
+    "Plot3D(S1,center=(0,0,0),size=(150,150),rot=[(pi/4,0,0)],scale=2)"
    ]
   },
   {
@@ -221,7 +221,7 @@
    ],
    "source": [
     "S2=Cylindrical(shape=Circular(radius=(50)),curvature=1/100.)\n",
-    "plot3D(S2,center=(0,0,0),size=(150,150),rot=[(-pi/4,0,0)],scale=2)"
+    "Plot3D(S2,center=(0,0,0),size=(150,150),rot=[(-pi/4,0,0)],scale=2)"
    ]
   },
   {
@@ -277,7 +277,7 @@
    ],
    "source": [
     "sa=Aspherical(shape=Rectangular(size=(5,5)),Ax=.2,Ay=.2,Kx=.1, Ky=.15, poly=poly2d((0,0,0,.5,0,.5)))\n",
-    "plot3D(sa,center=(0,0,5),size=(10,10),rot=[(-3*pi/10,pi/4,0)],scale=40)"
+    "Plot3D(sa,center=(0,0,5),size=(10,10),rot=[(-3*pi/10,pi/4,0)],scale=40)"
    ]
   },
   {
@@ -301,7 +301,7 @@
    ],
    "source": [
     "sa=Aspherical(shape=Circular(radius=2.5),Ax=.2,Ay=.2,Kx=.1, Ky=.15, poly=poly2d((0,0,0,.5,0,.5)))\n",
-    "plot3D(sa,center=(0,0,5),size=(10,10),rot=[(-3*pi/10,pi/4,0)],scale=40)"
+    "Plot3D(sa,center=(0,0,5),size=(10,10),rot=[(-3*pi/10,pi/4,0)],scale=40)"
    ]
   },
   {

--- a/examples/basic_course/03-SimpleComponents.ipynb
+++ b/examples/basic_course/03-SimpleComponents.ipynb
@@ -71,7 +71,7 @@
     "                       (S1,(0,0,5),(0,0,0)),\n",
     "                       (S2,(0,0,6.5),(0,0,0))\n",
     "                       ],material=material.schott[\"BK7\"])\n",
-    "plot3D(L1,size=(120,120),scale=3,rot=[(pi/3,0,0)])"
+    "Plot3D(L1,size=(120,120),scale=3,rot=[(pi/3,0,0)])"
    ]
   },
   {
@@ -120,7 +120,7 @@
     "                      (e1,(0,height/2,0),(pi/2,-pi/2,0)),\n",
     "                      (e2,(0,height/2,0),(pi/2,-pi/2,0))\n",
     "                      ],material=material.schott[\"BK7\"])\n",
-    "plot3D(P,size=(120,120),scale=3,rot=[(pi/6,pi/8,0)])"
+    "Plot3D(P,size=(120,120),scale=3,rot=[(pi/6,pi/8,0)])"
    ]
   },
   {
@@ -163,7 +163,7 @@
     "\n",
     "cube=System(complist=[(P1,(0,0,0),(0,0,0)),(P2,(0,0,0),(0,pi,0))],n=1.)\n",
     "\n",
-    "plot3D(cube,size=(120,120),scale=3,rot=[(pi/6,pi/8,0)])"
+    "Plot3D(cube,size=(120,120),scale=3,rot=[(pi/6,pi/8,0)])"
    ]
   },
   {
@@ -178,21 +178,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.9"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.0"
   }
  },
  "nbformat": 4,

--- a/examples/basic_course/04-Simple RayTraces.ipynb
+++ b/examples/basic_course/04-Simple RayTraces.ipynb
@@ -35,7 +35,7 @@
     "   Ray(pos=(0,0,0),dir=(0,0,1),wavelength=.650)]\n",
     "S.ray_add(R)\n",
     "S.propagate()\n",
-    "plot3D(S,center=(0,0,100),size=(200,100),scale=4,rot=[(0,pi/2,0),(pi/20,-pi/10,0)])"
+    "Plot3D(S,center=(0,0,100),size=(200,100),scale=4,rot=[(0,pi/2,0),(pi/20,-pi/10,0)])"
    ]
   },
   {
@@ -82,7 +82,7 @@
     "   Ray(pos=(0,0,0),dir=(0,0,1),wavelength=.650)]\n",
     "S.ray_add(R)\n",
     "S.propagate()\n",
-    "plot3D(S,center=(0,0,100),size=(200,100),scale=4,rot=[(0,pi/2,0),(pi/20,-pi/10,0)])"
+    "Plot3D(S,center=(0,0,100),size=(200,100),scale=4,rot=[(0,pi/2,0),(pi/20,-pi/10,0)])"
    ]
   },
   {
@@ -104,7 +104,7 @@
     "        R.append(Ray(pos=(0,0,0),dir=(x,y,100),wavelength=.650))\n",
     "S.ray_add(R)\n",
     "S.propagate()\n",
-    "plot3D(S,center=(0,0,100),size=(200,100),scale=4,rot=[(0,pi/2,0),(pi/20,-pi/10,0)])"
+    "Plot3D(S,center=(0,0,100),size=(200,100),scale=4,rot=[(0,pi/2,0),(pi/20,-pi/10,0)])"
    ]
   },
   {
@@ -128,7 +128,7 @@
     "        R.append(Ray(pos=(0,0,0),dir=(x,y,100),wavelength=.650))\n",
     "S.ray_add(R)\n",
     "S.propagate()\n",
-    "plot3D(S,center=(0,0,100),size=(250,100),scale=4,rot=[(0,pi/2,0),(pi/20,-pi/10,0)])"
+    "Plot3D(S,center=(0,0,100),size=(250,100),scale=4,rot=[(0,pi/2,0),(pi/20,-pi/10,0)])"
    ]
   },
   {
@@ -194,7 +194,7 @@
     "S.ray_add(R)\n",
     "S.propagate()\n",
     "\n",
-    "plot3D(S,center=(0,.35*60,60),size=(500,200),scale=2,rot=[(0,pi/2+.2,0),(-.1,0,0)])"
+    "Plot3D(S,center=(0,.35*60,60),size=(500,200),scale=2,rot=[(0,pi/2+.2,0),(-.1,0,0)])"
    ]
   },
   {
@@ -216,7 +216,7 @@
    },
    "outputs": [],
    "source": [
-    "plot3D(S,center=(0,.35*PCCD,PCCD),size=(50,30),scale=10,rot=[(0,pi/2+.1,0)])"
+    "Plot3D(S,center=(0,.35*PCCD,PCCD),size=(50,30),scale=10,rot=[(0,pi/2+.1,0)])"
    ]
   },
   {
@@ -278,7 +278,7 @@
     "S.ray_add(R)\n",
     "S.propagate()\n",
     "\n",
-    "plot3D(S,center=(0,.35*60,60),size=(500,200),scale=2,rot=[(0,pi/2+.2,0),(-.1,0,0)])"
+    "Plot3D(S,center=(0,.35*60,60),size=(500,200),scale=2,rot=[(0,pi/2+.2,0),(-.1,0,0)])"
    ]
   },
   {
@@ -300,7 +300,7 @@
    },
    "outputs": [],
    "source": [
-    "plot3D(S,center=(0,.35*PCCD,PCCD),size=(50,30),scale=10,rot=[(0,pi/2+.1,0)])"
+    "Plot3D(S,center=(0,.35*PCCD,PCCD),size=(50,30),scale=10,rot=[(0,pi/2+.1,0)])"
    ]
   },
   {
@@ -340,7 +340,7 @@
     "        R.append(Ray(pos=(0,0,0),dir=(x,y,100),wavelength=.650))\n",
     "S.ray_add(R)\n",
     "S.propagate()\n",
-    "plot3D(S,center=(0,0,100),size=(250,100),scale=4,rot=[(0,pi/4,0)])"
+    "Plot3D(S,center=(0,0,100),size=(250,100),scale=4,rot=[(0,pi/4,0)])"
    ]
   },
   {
@@ -374,7 +374,7 @@
     "        \n",
     "S.ray_add(R)\n",
     "S.propagate()\n",
-    "plot3D(S,center=(0,40,-10),size=(200,150),scale=4,rot=[(0,-pi/2,0)])\n"
+    "Plot3D(S,center=(0,40,-10),size=(200,150),scale=4,rot=[(0,-pi/2,0)])\n"
    ]
   },
   {
@@ -460,7 +460,7 @@
     "\n",
     "os.propagate()\n",
     "\n",
-    "display(plot3D(os,center=(0,0,200), size=(500,100),scale=2,rot=[(0,pi/2+.1,0),(-pi/4,0,0)]))\n",
+    "display(Plot3D(os,center=(0,0,200), size=(500,100),scale=2,rot=[(0,pi/2+.1,0),(-pi/4,0,0)]))\n",
     "\n",
     "display(spot_diagram(ccd))\n",
     "figure()\n",
@@ -504,7 +504,7 @@
     "S.ray_add(R1)\n",
     "S.propagate()\n",
     "spot_diagram(ccd)\n",
-    "plot3D(S,center=(0,0,0), size=(80,30),scale=8,rot=[(0,-3*pi/8,0)])"
+    "Plot3D(S,center=(0,0,0), size=(80,30),scale=8,rot=[(0,-3*pi/8,0)])"
    ]
   },
   {
@@ -581,7 +581,7 @@
     "os.propagate()\n",
     "\n",
     "\n",
-    "display(plot3D(os,center=(0,0,10), size=(50,20),scale=16,rot=[(0,-3*pi/8,0)]))\n",
+    "display(Plot3D(os,center=(0,0,10), size=(50,20),scale=16,rot=[(0,-3*pi/8,0)]))\n",
     "\n",
     "spot_diagram(ccd)\n"
    ]
@@ -654,7 +654,7 @@
     "os.ray_add(r_r)\n",
     "os.propagate()\n",
     "\n",
-    "display(plot3D(os,center=(0,0,500), size=(1200,200),scale=1,rot=[(0,pi/2,0),(.3,0,0)]))\n",
+    "display(Plot3D(os,center=(0,0,500), size=(1200,200),scale=1,rot=[(0,pi/2,0),(.3,0,0)]))\n",
     "\n",
     "spot_diagram_c(ccd)\n",
     "\n"
@@ -703,7 +703,7 @@
     "\n",
     "\n",
     "S.propagate()\n",
-    "plot3D(S,center=(-15,0,7), size=(50,50),scale=16,rot=[(0,-pi/2,0),(-pi/2+.1,-pi/4,0)])"
+    "Plot3D(S,center=(-15,0,7), size=(50,50),scale=16,rot=[(0,-pi/2,0),(-pi/2+.1,-pi/4,0)])"
    ]
   },
   {

--- a/examples/basic_course/05-Autocollimator.ipynb
+++ b/examples/basic_course/05-Autocollimator.ipynb
@@ -50,7 +50,7 @@
    },
    "outputs": [],
    "source": [
-    "plot3D(S,center=(0,0,300), size=(600,100),scale=2,rot=[(0,0,-3*pi/8),(0,3*pi/8,0)])"
+    "Plot3D(S,center=(0,0,300), size=(600,100),scale=2,rot=[(0,0,-3*pi/8),(0,3*pi/8,0)])"
    ]
   },
   {
@@ -105,7 +105,7 @@
    },
    "outputs": [],
    "source": [
-    "plot3D(S,center=(0,0,300), size=(600,100),scale=2,rot=[(0,0,-3*pi/8),(0,3*pi/8,0)])"
+    "Plot3D(S,center=(0,0,300), size=(600,100),scale=2,rot=[(0,0,-3*pi/8),(0,3*pi/8,0)])"
    ]
   },
   {

--- a/examples/basic_course/06-GeomWF.ipynb
+++ b/examples/basic_course/06-GeomWF.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "S.ray_add(R)\n",
     "S.propagate()\n",
-    "plot3D(S,center=(0,0,300), size=(600,100),scale=2,rot=[(0,0,-3*pi/8),(0,3*pi/8,0)])"
+    "Plot3D(S,center=(0,0,300), size=(600,100),scale=2,rot=[(0,0,-3*pi/8),(0,3*pi/8,0)])"
    ]
   },
   {

--- a/examples/basic_course/07-SimpleEODs.ipynb
+++ b/examples/basic_course/07-SimpleEODs.ipynb
@@ -78,7 +78,7 @@
     "\n",
     "os.propagate()\n",
     "\n",
-    "display(plot3D(os,center=(0,0,60), size=(150,150),scale=2,rot=[(0,0,pi/2),(0,pi/2+0.1,0)]))\n",
+    "display(Plot3D(os,center=(0,0,60), size=(150,150),scale=2,rot=[(0,0,pi/2),(0,pi/2+0.1,0)]))\n",
     "spot_diagram_c(ccd)\n"
    ]
   },
@@ -135,7 +135,7 @@
     "\n",
     "S.ray_add(R)\n",
     "S.propagate()\n",
-    "plot3D(S,center=(0,0,100),size=(250,100),scale=4,rot=[(0,pi/2,0),(pi/20,-pi/10,0)])"
+    "Plot3D(S,center=(0,0,100),size=(250,100),scale=4,rot=[(0,pi/2,0),(pi/20,-pi/10,0)])"
    ]
   },
   {
@@ -201,7 +201,7 @@
     "\n",
     "S.ray_add(R)\n",
     "S.propagate()\n",
-    "plot3D(S,center=(0,0,100),size=(250,100),scale=4,rot=[(0,pi/2,0),(pi/20,-pi/10,0)])"
+    "Plot3D(S,center=(0,0,100),size=(250,100),scale=4,rot=[(0,pi/2,0),(pi/20,-pi/10,0)])"
    ]
   },
   {
@@ -262,7 +262,7 @@
     "#S.ray_add(R1)\n",
     "\n",
     "S.propagate()\n",
-    "plot3D(S,center=(0,0,100),size=(250,100),scale=4,rot=[(0,pi/2,0),(pi/20,-pi/10,0)])"
+    "Plot3D(S,center=(0,0,100),size=(250,100),scale=4,rot=[(0,pi/2,0),(pi/20,-pi/10,0)])"
    ]
   },
   {


### PR DESCRIPTION
Ahora podemos hacer cosas como 
`p = Plot3D(....)` en cualquier environment, y llamar `p.show()` para abrir el visualizador de imagenes sin tener que estar dentro de IPython
Si en Ipython solo hacemos `Plot3D(...)` esto regresa una representacion jpeg que Ipython entiende y hace el embed automatico